### PR TITLE
Add defaults for items `P3_USER` and `P17_OWNER`

### DIFF
--- a/f120.sql
+++ b/f120.sql
@@ -21,7 +21,7 @@ wwv_flow_api.import_begin (
 );
 end;
 /
- 
+
 prompt APPLICATION 120 - utPLSQL Testing App
 --
 -- Application Export:
@@ -16627,6 +16627,8 @@ wwv_flow_api.create_page_item(
 ,p_name=>'P3_USER'
 ,p_item_sequence=>10
 ,p_item_plug_id=>wwv_flow_api.id(36687617713018983)
+,p_item_default=>'APP_SCHEMA'
+,p_item_default_type=>'ITEM'
 ,p_prompt=>'User'
 ,p_display_as=>'NATIVE_SELECT_LIST'
 ,p_named_lov=>'OWNER LIST'
@@ -19421,6 +19423,8 @@ wwv_flow_api.create_page_item(
 ,p_item_sequence=>10
 ,p_item_plug_id=>wwv_flow_api.id(66067199544684524)
 ,p_use_cache_before_default=>'NO'
+,p_item_default=>'APP_SCHEMA'
+,p_item_default_type=>'ITEM'
 ,p_prompt=>'User Name'
 ,p_source=>'P17_OWNER'
 ,p_source_type=>'ITEM'


### PR DESCRIPTION
## TL;DR:

Fix error:

```
SQL error: ORA-44001: invalid schema
```

## Details:

Error is generated when loading **page 17** from item `P17_OWNER` and **page 3** from item `P3_USER`.

Specifically, **page 17** uses item `P17_OWNER` to populate `P17_DIR_PATH` with  LOV `SUITE PATH LIST` which uses the SQL query:

```
select path d, path r from table(ut_runner.get_suites_info(NVL(:P17_OWNER,'NOBODY'))) where item_type = 'UT_LOGICAL_SUITE' order by path
```

With `:P17_OWNER` undefined, the `DBMS_ASSERT` function used in utPLSQL will cause an `ORA-44001: invalid schema` to be raised.  In the case of **page 17**, the page cannot even be rendered and results in an error (visible in the debug log).

## Resolution:

Add default values for items `P17_OWNER` and `P3_USER`.  For simplicity, setting to Application-item `:APP_SCHEMA`.
